### PR TITLE
Add option apt_update_mirror_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Configuration of package management tools.
 | `apt_default_unknown_debian` | `buster` | Release to default to if ansible can't detect it |
 | `apt_unattended_upgrades` | `False` | Whether to enable automatic, unattended upgrades |
 | `apt_update_release` | `ansible_distribution_release` | Which release to use for updates - can be overriden independently for testing |
+| `apt_security_mirror_enabled` | `True` | Some servers or devices does not need security mirrors like Debian testing or Raspian |
+| `apt_update_mirror_enabled` | `True` | Some servers or devices does not need update mirrors like Debian testing or Raspian |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,9 @@ apt_add_custom_repo: False
 apt_custom_repo_url: ""
 apt_custom_repo_key: ""
 
-# Option to disable security mirror for e.g Debian testing
+# Option to disable security/update mirror for e.g Debian testing or Raspbian
 apt_security_mirror_enabled: True
+apt_update_mirror_enabled: True
 
 # Which mirrors should we use?
 apt_default_mirror: "http://debian.ethz.ch/debian/"

--- a/templates/etc_apt_sources.list_debian.j2
+++ b/templates/etc_apt_sources.list_debian.j2
@@ -19,7 +19,10 @@ deb-src {{ apt_security_mirror }} {{ apt_update_release }}/updates {{ apt_debian
 {% endif %}
 
 {% endif %}
+
+{% if apt_update_mirror_enabled %}
 deb {{ apt_default_mirror }} {{ ansible_distribution_release }}-updates {{ apt_debian_package_types }}
+{% endif %}
 {% if apt_add_src %}
 deb-src {{ apt_default_mirror }} {{ ansible_distribution_release }}-updates {{ apt_debian_package_types }}
 {% endif %}

--- a/templates/etc_apt_sources.list_ubuntu.j2
+++ b/templates/etc_apt_sources.list_ubuntu.j2
@@ -11,7 +11,9 @@ deb-src {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-secu
 {% endif %}
 
 {% endif %}
+{% if apt_update_mirror_enabled %}
 deb {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-updates {{ apt_ubuntu_package_types }}
+{% endif %}
 {% if apt_add_src %}
 deb-src {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-updates {{ apt_ubuntu_package_types }}
 {% endif %}


### PR DESCRIPTION
This PR adds the option `apt_update_mirror_enabled` to make adding the update mirrors optional.